### PR TITLE
feat: add detailed error reporting to test notification endpoint

### DIFF
--- a/service/notification/sender.go
+++ b/service/notification/sender.go
@@ -48,6 +48,11 @@ func (ns *NotificationSender) SendTaskResetNotifications(tasks []*types.TaskRese
 	}
 }
 
+// SendSingleNotification sends a notification to a single subscription (public for testing)
+func (ns *NotificationSender) SendSingleNotification(sub *types.PushSubscription, task *types.TaskResetNotification) error {
+	return ns.sendNotification(sub, task)
+}
+
 func (ns *NotificationSender) sendNotification(sub *types.PushSubscription, task *types.TaskResetNotification) error {
 	// Build notification payload
 	payload := map[string]interface{}{


### PR DESCRIPTION
- Test endpoint now sends synchronously instead of async
- Returns subscription count and per-subscription results
- Shows success/error status for each notification attempt
- Add SendSingleNotification public method for testing
- Helps debug push notification delivery issues