### PR TITLE
feat: add urgency and detailed HTTP status logging to push notifications

### DIFF
--- a/service/notification/routes.go
+++ b/service/notification/routes.go
@@ -160,7 +160,9 @@ func (h *Handler) handleTestNotification(w http.ResponseWriter, r *http.Request)
 			"subscriptionId": sub.SubscriptionId,
 			"endpoint":       sub.Endpoint[:50] + "...", // truncate for readability
 		}
-		if err := h.sender.SendSingleNotification(sub, testNotification); err != nil {
+		statusCode, err := h.sender.SendSingleNotificationWithStatus(sub, testNotification)
+		result["httpStatus"] = statusCode
+		if err != nil {
 			result["success"] = false
 			result["error"] = err.Error()
 		} else {


### PR DESCRIPTION
- Set urgency to High for iOS push delivery
- Add detailed logging of push service HTTP responses
- Return HTTP status codes in test endpoint for debugging
- Create SendSingleNotificationWithStatus for testing
- Log non-2xx responses from push service

Helps debug iOS push notification delivery issues